### PR TITLE
added lecl qa chain workflow and reranking on cpu

### DIFF
--- a/enterprise_knowledge_retriever/config.yaml
+++ b/enterprise_knowledge_retriever/config.yaml
@@ -16,6 +16,8 @@ retrieval:
     "chunk_size": 1200
     "chunk_overlap": 240
     "db_type": "chroma"
-    "k_retrieved_documents": 3
+    "k_retrieved_documents": 15
     "score_threshold": 0.6
+    "rerank": True
+    "final_k_retrieved_documents": 3
 

--- a/enterprise_knowledge_retriever/streamlit/app.py
+++ b/enterprise_knowledge_retriever/streamlit/app.py
@@ -22,7 +22,7 @@ logging.info("URL: http://localhost:8501")
 def handle_userinput(user_question):
     if user_question:
         with st.spinner("Processing..."):
-            response = st.session_state.conversation.invoke({"question": user_question})
+            response = st.session_state.conversation.qa_retrieval(user_question)
         st.session_state.chat_history.append(user_question)
         st.session_state.chat_history.append(response["answer"])
 
@@ -111,9 +111,8 @@ def main():
                     vectorstore = documentRetrieval.create_vector_store(text_chunks, embeddings, output_db=None)
                     st.session_state.vectorstore = vectorstore
                     # create conversation chain
-                    st.session_state.conversation = documentRetrieval.get_qa_retrieval_chain(
-                        st.session_state.vectorstore
-                    )
+                    documentRetrieval.init_retriever(vectorstore)
+                    st.session_state.conversation = documentRetrieval
                     st.toast(f"File uploaded! Go ahead and ask some questions",icon='🎉')
             st.markdown("[Optional] Save database for reuse")
             save_location = st.text_input("Save location", "./data/my-vector-db").strip()
@@ -128,9 +127,8 @@ def main():
                     vectorstore = documentRetrieval.create_vector_store(text_chunks, embeddings, output_db=save_location)
                     st.session_state.vectorstore = vectorstore
                     # create conversation chain
-                    st.session_state.conversation = documentRetrieval.get_qa_retrieval_chain(
-                        st.session_state.vectorstore
-                    ) 
+                    documentRetrieval.init_retriever(vectorstore)
+                    st.session_state.conversation = documentRetrieval 
                     st.toast(f"File uploaded and saved to {PERSIST_DIRECTORY}! Go ahead and ask some questions",icon='🎉')
 
         else:
@@ -157,9 +155,8 @@ def main():
                             st.session_state.vectorstore = vectorstore
 
                             # create conversation chain
-                            st.session_state.conversation = documentRetrieval.get_qa_retrieval_chain(
-                                st.session_state.vectorstore
-                            )
+                            documentRetrieval.init_retriever(vectorstore)
+                            st.session_state.conversation = documentRetrieval
                         else:
                             st.error("database not present at " + db_path, icon="🚨")
 
@@ -178,9 +175,9 @@ def main():
             )
             if st.button("Reset conversation"):
                 # reset create conversation chain
-                st.session_state.conversation = documentRetrieval.get_qa_retrieval_chain(
-                    st.session_state.vectorstore
-                )
+                # st.session_state.conversation = documentRetrieval.get_qa_retrieval_chain(
+                #     st.session_state.vectorstore
+                # )
                 st.session_state.chat_history = []
                 st.toast(
                     "Conversation reset. The next response will clear the history on the screen"


### PR DESCRIPTION
I have added early implementation of an lecl method of performing the qa chain, which makes enabling reranking simpler.  There will likely need to be some refactoring as I expect code duplication from the lang graph work.