### PR TITLE
Documentation and legibility edits/fixes

### DIFF
--- a/CoE_jump_start/README.md
+++ b/CoE_jump_start/README.md
@@ -160,7 +160,7 @@ Contributions are welcome! If you have any suggestions, bug reports, or feature 
 
 ## License
 
-This project is licensed under the MIT License.
+This project is licensed under the Apache 2.0 license. See the `LICENSE.md` file in the parent folder (`AI-STARTER-KIT`) for more details.
 
 ## Acknowledgements
 

--- a/CoE_jump_start/README.md
+++ b/CoE_jump_start/README.md
@@ -14,6 +14,7 @@ This repository provides a Python script and a Jupyter Notebook that demonstrate
 <!-- TOC -->
 - [Features](#features)
 - [Prerequisites](#prerequisites)
+- [Key dependencies](#key-dependencies)
 - [Installation](#installation)
 - [Starter kit usage](#starter-kit-usage)
   - [Calling CoE models with the Python script](#calling-coe-models-with-the-python-script)
@@ -40,13 +41,18 @@ This AI starter kit supports the following features:
 
 ## Prerequisites
 
-- Python 3.11.3+
+- Python (>3.11.3 and <3.12)
+
+## Key dependencies
+
+_(Installed below)_
 - Langchain
 - Sentence Transformers
 - YAML
 - Requests
 
 ## Installation
+_These steps assume a Mac/Linux/Unix shell environment. If using Windows, you will need to adjust some commands for navigating folders, activating virtual environments, etc._
 
 1. Clone the main repository and cd into CoE starter kit:
 
@@ -55,17 +61,19 @@ This AI starter kit supports the following features:
   cd CoE_jump_start
   ```
 
-2. Install the required dependencies:
-  ```bash
-  - With pip: `pip install -r requirements.txt` 
-  - With poetry: `poetry install --no-root`
-  ```
-2b. - Create a venv: 
+2. (Recommended) Create a virtual environment and activate it: 
   ```bash
   python<version> -m venv <virtual-environment-name>
+  source <virtual-environment-name>/bin/activate
   ```
 
-3. Set up the config.yaml file with your API credentials and preferences. For example:
+3. Install the required dependencies:
+  ```bash
+  pip install -r requirements.txt # With pip
+  poetry install --no-root # With poetry
+  ```
+
+4. Set up the `config.yaml` file with your API credentials and preferences. For example:
   ```yaml
   api: sambastudio
 
@@ -82,7 +90,7 @@ This AI starter kit supports the following features:
    db_type: "faiss"
   ```
 
-4. In the project root directory, create a .env file and add the necessary API keys based on your chosen entry point:
+4. In the CoE starter kit root directory, create a `.env` file and add the necessary API keys based on your chosen entry point:
 
 ```env
 # NEEDED FOR SAMBAVERSE
@@ -103,7 +111,7 @@ EMBED_ENDPOINT_ID="your-samba-studio-embedding_model-endpointid"
 EMBED_API_KEY="your-samba-studio-embedding_model-apikey"
 ```
 
-The script supports both Sambaverse and SambaStudio APIs. Depending on which API you want to use, provide the corresponding API keys and URLs in the .env file. If you want to use the SNSDK instead of requests, make sure you have it installed and configured with your credentials.
+The script supports both Sambaverse and SambaStudio APIs. Depending on which API you want to use, provide the corresponding API keys and URLs in the `.env` file. If you want to use the `SNSDK` instead of `requests`, make sure you have it installed and configured with your credentials.
 
 ## Starter kit usage
 

--- a/CoE_jump_start/README.md
+++ b/CoE_jump_start/README.md
@@ -42,6 +42,10 @@ This AI starter kit supports the following features:
 ## Prerequisites
 
 - Python (>3.11.3 and <3.12)
+- A [Sambaverse](https://sambaverse.sambanova.ai/) account
+- A [SambaStudio](https://docs.sambanova.ai/sambastudio/latest/index.html) account with at least two running endpoints:
+  - A Composition of Experts (CoE) model
+  - A text embedding model with a batch size larger than 1 (set/view this via the model parameters)
 
 ## Key dependencies
 
@@ -90,12 +94,16 @@ _These steps assume a Mac/Linux/Unix shell environment. If using Windows, you wi
    db_type: "faiss"
   ```
 
-4. In the CoE starter kit root directory, create a `.env` file and add the necessary API keys based on your chosen entry point:
+4. In the CoE starter kit root directory (that is, in the parent folder to where this `README` is saved), create a `.env` file and add the necessary API keys based on your chosen entry point:
 
 ```env
 # NEEDED FOR SAMBAVERSE
-SAMBAVERSE_API_KEY="133-adb-you-key-here"
-SAMBAVERSE_URL="https://yoururl"
+SAMBAVERSE_API_KEY="133-adb-you-key-here" # Found in your profile (upper right corner of Sambaverse)
+SAMBAVERSE_URL="https://sambaverse.sambanova.ai/" # Adjust as needed
+
+# For below, SambaStudio endpoint URLs follow the format:
+# <BASE_URL>/api/predict/generic/<PROJECT_ID>/<ENDPOINT_ID>
+# Both the endpoint URL and the endpoint API key can be found by clicking into an endpoint's details page
 
 # NEEDED FOR SAMBASTUDIO COE MODEL
 BASE_URL="https://yoursambstudio.url"
@@ -150,7 +158,6 @@ The script and notebook support various models for calling CoE, including:
 * deepseek-llm-67b-chat
 * medicine-chat
 * law-chat
-
 
 For a full list of supported CoE models, see the [Supported Models](https://docs.sambanova.ai/sambastudio/latest/samba-1.html#_samba_1_expert_models) documentation.
 

--- a/CoE_jump_start/config.yaml
+++ b/CoE_jump_start/config.yaml
@@ -39,8 +39,8 @@ expert_prompt: |
   {input}
 
   Always remember the following instructions while classifying the given statement:
-  - Think carefully and if you are not highly certain then classify the  given statement as 'None of the above'
-  - Always begin your response by putting the classified category of the given statement after  '<<detected category>>:'
+  - Think carefully and if you are not highly certain then classify the given statement as 'None of the above'
+  - Always begin your response by putting the classified category of the given statement after '<<detected category>>:'
   - Explain you answer
 
   [/INST]

--- a/CoE_jump_start/requirements.txt
+++ b/CoE_jump_start/requirements.txt
@@ -41,6 +41,7 @@ docx2txt==0.8
 emoji==2.10.1
 evaluate==0.4.1
 executing==2.0.1
+fake_useragent==1.5.1
 fastapi==0.109.2
 filelock==3.13.1
 filetype==1.2.0

--- a/CoE_jump_start/use_CoE_model.ipynb
+++ b/CoE_jump_start/use_CoE_model.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook demonstrates how to use the `use_coe_model.py` script to call the Composition Of Experts (CoE) models using different approaches. We'll explore three examples:\n",
     "\n",
-    "1. Using SambaVerse to call CoE Model\n",
+    "1. Using Sambaverse to call CoE Model\n",
     "2. Using SambaStudio to call CoE with Named Expert\n",
     "3. Using SambaStudio to call CoE with Routing\n",
     "\n",
@@ -19,89 +19,62 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "1234568",
-   "metadata": {},
-   "source": [
-    "## Example 1: Using SambaVerse to call CoE Model\n",
-    "\n",
-    "In this example, we'll use SambaVerse to call the CoE model. SambaVerse provides the expert name and their API key."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "497a4fd6",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "import sys\n",
+    "import yaml\n",
+    "\n",
+    "from use_CoE_model import SambaNovaEmbeddingModel, SambaverseEndpoint, SambaNovaEndpoint, create_stuff_documents_chain, create_retrieval_chain, get_expert, get_expert_val\n",
+    "from langchain_community.embeddings import HuggingFaceEmbeddings\n",
+    "from langchain_community.document_loaders import WebBaseLoader\n",
+    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
+    "from langchain.vectorstores import Chroma\n",
+    "from langchain.prompts import ChatPromptTemplate\n",
     "\n",
     "current_dir = os.getcwd()\n",
     "kit_dir = os.path.abspath(os.path.join(current_dir, \"..\"))\n",
     "repo_dir = os.path.abspath(os.path.join(kit_dir, \"..\"))\n",
+    "CONFIG_PATH = os.path.join(current_dir, \"config.yaml\")\n",
     "\n",
     "sys.path.append(kit_dir)\n",
     "sys.path.append(repo_dir)"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cf862ab3",
+   "metadata": {},
+   "source": [
+    "## Example 1: Using Sambaverse to call CoE Model\n",
+    "\n",
+    "In this example, we'll use Sambaverse to call the CoE model. Sambaverse provides the expert name and their API key."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "1234569",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:sentence_transformers.SentenceTransformer:Load pretrained SentenceTransformer: sentence-transformers/all-mpnet-base-v2\n",
-      "INFO:sentence_transformers.SentenceTransformer:Use pytorch device_name: mps\n",
-      "INFO:langchain_community.document_loaders.web_base:fake_useragent not found, using default user agent.To get a realistic header for requests, `pip install fake_useragent`.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "LangSmith is primarily designed for building production-grade LLM applications. However, it does provide some capabilities that can be useful for testing purposes.\n",
-      "\n",
-      "One way to use LangSmith for testing is by using its tracing capabilities. Tracing allows you to record and analyze the execution of your LLM application. This can be useful for identifying and debugging issues in your application.\n",
-      "\n",
-      "Another way to use LangSmith for testing is by using its evaluation capabilities. Evaluation allows you to automatically grade the output of your LLM application against a set of predefined criteria. This can be useful for quickly identifying the performance of your application and for providing objective feedback to your development team.\n",
-      "\n",
-      "In summary, while LangSmith is primarily designed for building production-grade LLM applications, it does provide some capabilities that can be useful for testing purposes. These capabilities include tracing and evaluation. By using these capabilities, you can record and analyze the execution of your LLM application, identify and debug issues in your application, and provide objective feedback to your development team.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from use_CoE_model import SambaNovaEmbeddingModel, SambaverseEndpoint, create_stuff_documents_chain, create_retrieval_chain\n",
-    "from langchain_community.document_loaders import WebBaseLoader\n",
-    "from langchain_community.embeddings import HuggingFaceEmbeddings\n",
-    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-    "from langchain.vectorstores import Chroma\n",
-    "from langchain.prompts import ChatPromptTemplate\n",
-    "import os\n",
-    "import yaml\n",
-    "\n",
     "# Update the config.yaml file with the following:\n",
     "# api: sambaverse\n",
     "# llm:\n",
     "#   sambaverse_model_name: \"Mistral/Mistral-7B-Instruct-v0.2\"\n",
     "#   samabaverse_select_expert: \"Mistral-7B-Instruct-v0.2\"\n",
     "\n",
-    "# Load the config.yaml\n",
-    "CONFIG_PATH = os.path.join(current_dir, \"config.yaml\")\n",
-    "\n",
     "with open(CONFIG_PATH, \"r\") as yaml_file:\n",
     "    config = yaml.safe_load(yaml_file)\n",
     "api_info = config[\"api\"]\n",
     "llm_info = config[\"llm\"]\n",
     "\n",
-    "\n",
-    "# Since Embedding Models are only available on SambaStudio and not SambaVerse we create a local Hugging Face Embeddings Object\n",
-    "# In the SambaStudio examples later we utilise an Embeddings Models hosted on SambaStudio\n",
+    "# Since Embedding Models are only available on SambaStudio and not Sambaverse we create a local Hugging Face Embeddings Object\n",
+    "# In the SambaStudio examples later, we use an Embeddings Models hosted on SambaStudio\n",
     "embeddings = HuggingFaceEmbeddings()\n",
     "\n",
     "# Load documents and split into chunks\n",
@@ -111,7 +84,7 @@
     "documents = text_splitter.split_documents(docs)\n",
     "\n",
     "# Create a vector database using Chroma\n",
-    "vector = Chroma.from_documents(documents, embeddings,collection_name='sambaverse_coe_aisk')\n",
+    "vector = Chroma.from_documents(documents, embeddings, collection_name='sambaverse_coe_aisk')\n",
     "\n",
     "# Define the prompt template\n",
     "prompt = ChatPromptTemplate.from_template(\n",
@@ -160,40 +133,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "1234571",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:langchain_community.document_loaders.web_base:fake_useragent not found, using default user agent.To get a realistic header for requests, `pip install fake_useragent`.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "?\n",
-      "\n",
-      "Answer: Based on the provided context, LangSmith is a language processing tool that can be used within applications. However, the context does not provide specific information on how to integrate LangSmith into applications. For more detailed instructions, you may want to refer to LangSmith's official documentation or contact their support team for assistance.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from use_CoE_model import SambaNovaEmbeddingModel, SambaNovaEndpoint, create_stuff_documents_chain, create_retrieval_chain\n",
-    "from langchain_community.document_loaders import WebBaseLoader\n",
-    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-    "from langchain.vectorstores import Chroma\n",
-    "from langchain.prompts import ChatPromptTemplate\n",
-    "\n",
     "# Update the config.yaml file with the following:\n",
     "# api: sambastudio\n",
     "# llm:\n",
     "#   samabaverse_select_expert: \"Mistral-7B-Instruct-v0.2\"\n",
-    "# Load the config.yaml\n",
-    "CONFIG_PATH = os.path.join(current_dir, \"config.yaml\")\n",
     "\n",
     "with open(CONFIG_PATH, \"r\") as yaml_file:\n",
     "    config = yaml.safe_load(yaml_file)\n",
@@ -211,7 +159,7 @@
     "documents = text_splitter.split_documents(docs)\n",
     "\n",
     "# Create a vector database using Chroma\n",
-    "vector = Chroma.from_documents(documents, embeddings,collection_name='sambastudio_coe_aisk')\n",
+    "vector = Chroma.from_documents(documents, embeddings, collection_name='sambastudio_coe_aisk')\n",
     "\n",
     "# Define the prompt template\n",
     "prompt = ChatPromptTemplate.from_template(\n",
@@ -258,53 +206,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "1234573",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:langchain_community.document_loaders.web_base:fake_useragent not found, using default user agent.To get a realistic header for requests, `pip install fake_useragent`.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Router expert response: {'data': [{'stop_reason': 'end_of_text', 'completion': ' Based on the information provided, I would classify the message \"Tell me how I can use langsmith for testing\" as \"Code Generation\".\\n\\n<<detected category>>: Code Generation\\n\\nThe message is asking for information on how to use a tool called \"langsmith\" for testing, which is a programming concept related to writing and debugging code. Therefore, it falls under the category of \"Code Generation\".', 'total_tokens_count': 400.0, 'prompt': '{\"conversation_id\": \"sambaverse-conversation-id\", \"messages\": [{\"message_id\": 0, \"role\": \"user\", \"content\": \"Tell me how I can use langsmith for testing\"}], \"prompt\": \"<s>[INST] \\\\n\\\\nA message can be classified as only one of the following categories: \\'finance\\',  \\'economics\\',  \\'maths\\',  \\'code generation\\', \\'legal\\', \\'medical\\', \\'history\\' or \\'None of the above\\'.  \\\\n\\\\nExamples for few of these categories are given below:\\\\n- \\'code generation\\': Write a python program\\\\n- \\'code generation\\': Debug the following code\\\\n- \\'None of the above\\': Who are you?\\\\n- \\'None of the above\\': What are you?\\\\n- \\'None of the above\\': Where are you?\\\\n\\\\nBased on the above categories, classify this message: \\\\n\\\\nTell me how I can use langsmith for testing\\\\n\\\\nAlways remember the following instructions while classifying the given statement:\\\\n- Think carefully and if you are not highly certain then classify the  given statement as \\'None of the above\\'\\\\n- Always begin your response by putting the classified category of the given statement after  \\'<<detected category>>:\\'\\\\n- Explain you answer\\\\n\\\\n[/INST]\\\\n\"}', 'logprobs': {'top_logprobs': None, 'text_offset': None}, 'tokens': ['', 'Based', 'on', 'the', 'information', 'provided', ',', 'I', 'would', 'class', 'ify', 'the', 'message', '\"', 'T', 'ell', 'me', 'how', 'I', 'can', 'use', 'lang', 'sm', 'ith', 'for', 'testing', '\"', 'as', '\"', 'Code', 'Generation', '\".', '\\n', '\\n', '<<', 'det', 'ected', 'category', '>>', ':', 'Code', 'Generation', '\\n', '\\n', 'The', 'message', 'is', 'asking', 'for', 'information', 'on', 'how', 'to', 'use', 'a', 'tool', 'called', '\"', 'lang', 'sm', 'ith', '\"', 'for', 'testing', ',', 'which', 'is', 'a', 'programming', 'concept', 'related', 'to', 'writing', 'and', 'debugging', 'code', '.', 'Therefore', ',', 'it', 'falls', 'under', 'the', 'category', 'of', '\"', 'Code', 'Generation', '\".']}]}\n",
-      "Routing Named Expert: Code expert\n",
-      "Named expert Model Name: deepseek-llm-67b-chat\n",
-      "Response:  my LLM application.\n",
-      "\n",
-      "    Answer: To use LangSmith for testing your LLM application, you can follow these steps:\n",
-      "\n",
-      "    1. Familiarize yourself with LangSmith: Start by reading the User Guide to learn about the workflows LangSmith supports at each stage of the LLM application lifecycle. This will give you a better understanding of how LangSmith can be used for testing your LLM application.\n",
-      "\n",
-      "    2. Explore the Evaluation capabilities: In the provided context, there is a section on Evaluation. Learn about the evaluation capabilities of LangSmith, which will help you assess the performance of your LLM application.\n",
-      "\n",
-      "    3. Utilize the Prompt Hub: The Prompt Hub is a prompt management tool built into LangSmith. Learn about it to understand how you can use it to manage and test your LLM application's prompts.\n",
-      "\n",
-      "    4. Review Additional Resources: The provided context mentions several additional resources, such as the LangSmith Cookbook, LangChain Python documentation, and LangChain JS documentation. Review these resources to gain more insights into using LangSmith for testing your LLM application.\n",
-      "\n",
-      "    5. Join the Discord community: Engage with the LangChain community on Discord to discuss your questions, share experiences, and learn from others who are using LangSmith for testing their LLM applications.\n",
-      "\n",
-      "By following these steps, you can effectively use LangSmith for testing your LLM application and ensure its performance and functionality meet your requirements.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from use_CoE_model import SambaNovaEmbeddingModel, SambaNovaEndpoint, create_stuff_documents_chain, create_retrieval_chain, get_expert, get_expert_val\n",
-    "from langchain_community.document_loaders import WebBaseLoader\n",
-    "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
-    "from langchain.vectorstores import Chroma\n",
-    "from langchain.prompts import ChatPromptTemplate\n",
-    "\n",
     "# Update the config.yaml file with the following:\n",
     "# api: sambastudio\n",
     "# llm:\n",
     "#   coe_routing: true\n",
+    "\n",
+    "with open(CONFIG_PATH, \"r\") as yaml_file:\n",
+    "    config = yaml.safe_load(yaml_file)\n",
+    "api_info = config[\"api\"]\n",
+    "llm_info = config[\"llm\"]\n",
     "\n",
     "# Create a SambaNovaEmbeddingModel object\n",
     "snsdk_model = SambaNovaEmbeddingModel()\n",
@@ -377,22 +292,24 @@
    "id": "1234574",
    "metadata": {},
    "source": [
-    "In each example, we walk through the following steps:\n",
+    "## Conclusion\n",
     "\n",
-    "1. Update the `config.yaml` file with the appropriate API information and LLM parameters.\n",
-    "2. Create a `SambaNovaEmbeddingModel` object for embeddings.\n",
-    "3. Load documents from a URL and split them into chunks.\n",
-    "4. Create a vector database using Chroma.\n",
-    "5. Define the prompt template.\n",
-    "6. Set up the language model based on the example configuration.\n",
-    "7. Create the document chain and retrieval chain.\n",
-    "8. Invoke the retrieval chain with the user query.\n",
-    "9. Print the response.\n",
+    "In each example, we walked through the following steps:\n",
+    "\n",
+    "1. Update the `config.yaml` file with the appropriate API information and LLM parameters\n",
+    "2. Create a `SambaNovaEmbeddingModel` (or a `HuggingFaceEmbeddings`) object for embeddings\n",
+    "3. Load documents from a URL and split them into chunks\n",
+    "4. Create a vector database using Chroma\n",
+    "5. Define the prompt template\n",
+    "6. Set up the language model based on the example configuration\n",
+    "7. Create the document chain and retrieval chain\n",
+    "8. Invoke the retrieval chain with the user query\n",
+    "9. Print the response\n",
     "\n",
     "For Example 3, we additionally:\n",
-    "- Call `get_expert()` to determine the appropriate expert based on the user query.\n",
-    "- Extract the expert name using `get_expert_val()`.\n",
-    "- Look up the model name based on the expert.\n",
+    "- Called `get_expert()` to determine the appropriate expert based on the user query.\n",
+    "- Extracted the expert name using `get_expert_val()`.\n",
+    "- Looked up the model name based on the expert.\n",
     "\n",
     "Feel free to explore and experiment with different configurations and queries to see how the CoE models respond!\n",
     "\n",
@@ -416,7 +333,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/CoE_jump_start/use_CoE_model.py
+++ b/CoE_jump_start/use_CoE_model.py
@@ -23,7 +23,7 @@ import json
 import requests
 
 # Use embeddings As Part of Langchain
-from langchain.vectorstores import Chroma
+from langchain_community.vectorstores import Chroma
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/fine_tuning_embeddings/README.md
+++ b/fine_tuning_embeddings/README.md
@@ -189,7 +189,7 @@ We welcome contributions! Feel free to improve the process or add features by su
 
 # License
 
-This project is licensed under the MIT License.
+This project is licensed under the Apache 2.0 license. See the `LICENSE.md` file in the parent folder (`AI-STARTER-KIT`) for more details.
 
 # Acknowledgments
 


### PR DESCRIPTION
90% of the edits are purely superficial: changes to the README and to code comments that make the first-time user's experience a little more friendly. I doubt these will cause any concern.
Also some typo fixes, getting rid of some extra whitespaces, and correcting the licensing terms wherever they are discussed.
The only potentially contentious fix is reshuffling the `import`s in the CoE jumpstart's notebook: I moved them all to a preface cell so that they are only done once. This reduced repetition, and it turns out that many of the `import`s in the original file weren't even being used anyways.

"Tested" the changes by ensuring that the CoE code files (IPYNB and PY) both continue to run without error. There is an oddity, though, in that the PY file (but not the IPYNB) throws the following warning:
```
LangChainDeprecationWarning: Importing vector stores from langchain is deprecated. Importing from langchain will no longer be supported as of langchain==0.2.0. Please import from langchain-community instead:

`from langchain_community.vectorstores import Chroma`.

To install langchain-community run `pip install -U langchain-community`.
```
It's not an error, it's not obvious where this warning comes from, and I made no edits to the PY file anyway. So: I didn't look into this. Someone else might want to.