### PR TITLE
Fixed orphaned complex_rag link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Questions? Just <a href="https://discord.gg/XF5Sf2sa" target="_blank">message us
 </td>
 <td width="75%">This example guide shows a simple integration with Continue VSCode and JetBrains extension using SambaNova platforms, to use Sambanova's hosted models as your custom coding assistant. </td>
 </tr>
-</tr><td width="25%"><a href="complex_rag/README.md">Complex RAG</a> 
+</tr><td width="25%"><a href="workshops/genai_summit/complex_rag/README.md">Complex RAG</a> 
 </td>
 <td width="75%"> Sample implementation of a complex RAG workflow using the SambaNova platform to get answers to questions about your documents. Includes a runnable demo. </td>
 </tr>


### PR DESCRIPTION
As far as I can tell (via searching the whole repo), this is the only hyperlink that was broken by the move from 

complex_rag -> workshops/genai_summit/complex_rag