### PR TITLE
Bugfix: Patch to reduce tokenizer decoding on template prompt

### DIFF
--- a/benchmarking/requirements.txt
+++ b/benchmarking/requirements.txt
@@ -25,3 +25,4 @@ tensorflow==2.16.1
 torch==2.2.2
 tqdm==4.66.1
 transformers==4.41.1
+joblib==1.4.2

--- a/benchmarking/run_custom_dataset.sh
+++ b/benchmarking/run_custom_dataset.sh
@@ -9,7 +9,7 @@ python src/evaluator.py \
 --timeout 600 \
 --input-file-path "<CUSTOM DATASET PATH HERE>" \
 --save-llm-responses False \
---sampling-params '{"max_tokens": 256}' \
+--sampling-params '{"max_tokens_to_generate": 256}' \
 --llm-api sncloud
 
 # Notes:
@@ -38,8 +38,4 @@ python src/evaluator.py \
 # 4. For SambaNovaCloud endpoints, change the llm-api parameter to "snloud" and use the model name directly.
 #   For example:
 #      --model-name "llama3-8b"
-#
-# 5. You can modify the number of maximum tokens depending on the LLM endpoint type.
-#   If it's "sambastudio": add or modify in the `--sampling-params` dictionary the `max_tokens_to_generate` key and a value
-#   If it's "snloud": add or modify in the `--sampling-params` dictionary the `max_tokens` key and a value   
 #

--- a/benchmarking/src/performance_evaluation.py
+++ b/benchmarking/src/performance_evaluation.py
@@ -8,6 +8,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+import joblib
 import yaml
 
 file_location = Path(__file__).parent.resolve()
@@ -127,7 +128,16 @@ class BasePerformanceEvaluator(abc.ABC):
         Returns:
             str: adjusted text
         """
-        tokens = self.tokenizer.tokenize(text)
+        model = self.model_name.replace('COE/', '').replace('/', '_')
+        tokenized_text_filename = f'tokenized_text_variable_{model}.bin'
+        tokenized_text_filepath = f'{file_location}/../prompts/{tokenized_text_filename}'
+
+        if not Path(tokenized_text_filepath).exists():
+            tokens = self.tokenizer.tokenize(text)
+            joblib.dump(tokens, tokenized_text_filepath)
+        else:
+            tokens = joblib.load(tokenized_text_filepath)
+
         token_count = len(tokens)
 
         if token_count > target_token_count:


### PR DESCRIPTION
- Added logic to create decoded template prompts per model in synthetic speed eval
- Increased speed by 70% before launching concurrent requests
- Fixed bug related to custom process and max tokens parameter
- Tested all kit's functionalities and prod mode