### PR TITLE
Bugfix: Uncomment lines for financial_assistant in tests

### DIFF
--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -41,7 +41,7 @@ CLI_COMMAND_TIMEOUT = 1200  # 20 minutes
 STARTER_KITS: List[str] = [
     'benchmarking',
     'enterprise_knowledge_retriever',
-    # 'financial_assistant',
+    'financial_assistant',
     'function_calling',
     'search_assistant',
     'image_search',
@@ -65,7 +65,7 @@ CLI_TEST_COMMANDS: Dict[str, str] = {
         '--llm-api sncloud'
     ),
     'enterprise_knowledge_retriever': 'python tests/ekr_test.py',
-    # 'financial_assistant': 'python tests/financial_assistant_test.py',
+    'financial_assistant': 'python tests/financial_assistant_test.py',
     'function_calling': 'python tests/fc_test.py',
     'multimodal_knowledge_retriever': ('python tests/multimodal_knowledge_retriever_test.py'),
     'post_call_analysis': 'python tests/pca_test.py',


### PR DESCRIPTION
Tests are now passing, after a temporary problem.