### PR TITLE
Bugfix: Scratch folder at container level.

### DIFF
--- a/financial_assistant/.streamlit/config.toml
+++ b/financial_assistant/.streamlit/config.toml
@@ -1,5 +1,4 @@
 [theme]
-base="dark"
 
 # Primary accent for interactive elements
 primaryColor='#EE7624'

--- a/financial_assistant/.streamlit/config.toml
+++ b/financial_assistant/.streamlit/config.toml
@@ -1,5 +1,5 @@
 [theme]
-base="light"
+base="dark"
 
 # Primary accent for interactive elements
 primaryColor='#EE7624'

--- a/financial_assistant/.streamlit/config.toml
+++ b/financial_assistant/.streamlit/config.toml
@@ -1,4 +1,5 @@
 [theme]
+base="light"
 
 # Primary accent for interactive elements
 primaryColor='#EE7624'

--- a/financial_assistant/constants.py
+++ b/financial_assistant/constants.py
@@ -67,7 +67,7 @@ DEFAULT_PDF_TITLE = 'Financial Report'
 # Cache directory
 CACHE_DIR = os.path.join(kit_dir, 'streamlit/cache')
 if prod_mode:
-    CACHE_DIR = os.path.join(repo_dir, 'scratch/financial_assistant/cache', f'cache_{SESSION_ID}')
+    CACHE_DIR = os.path.abspath(os.path.join(kit_dir, '../../scratch/financial_assistant/cache', f'cache_{SESSION_ID}'))
 
 # Main cache directories
 HISTORY_PATH = os.path.join(CACHE_DIR, 'chat_history.txt')


### PR DESCRIPTION
Set the scratch folder at container level, i.e. two levels above the financial assistant kit.