### PR TITLE
Improvement: Path names in session state and code cleanup

### DIFF
--- a/financial_assistant/config.yaml
+++ b/financial_assistant/config.yaml
@@ -1,4 +1,4 @@
-prod_mode: True
+prod_mode: False
 
 llm: 
     "api": "sncloud" #  Set either `sambastudio` or `sncloud`

--- a/financial_assistant/config.yaml
+++ b/financial_assistant/config.yaml
@@ -1,4 +1,4 @@
-prod_mode: False
+prod_mode: True
 
 llm: 
     "api": "sncloud" #  Set either `sambastudio` or `sncloud`

--- a/financial_assistant/src/tools_database.py
+++ b/financial_assistant/src/tools_database.py
@@ -86,7 +86,7 @@ def create_stock_database(
 
     # Create SQL database
     company_tables_dict = store_company_dataframes_to_sqlite(
-        db_name=streamlit.session_state['DB_PATH'], company_data_dict=company_data_dict
+        db_name=streamlit.session_state.db_path, company_data_dict=company_data_dict
     )
 
     return company_tables_dict
@@ -108,7 +108,7 @@ def store_company_dataframes_to_sqlite(
         A dictionary with company symbols as keys and a list of SQL table names as values.
     """
     # Connect to the SQLite database
-    engine = create_engine(f'sqlite:///{streamlit.session_state["DB_PATH"]}')
+    engine = create_engine(f'sqlite:///{streamlit.session_state.db_path}')
 
     # Create a dictionary with company names as keys and SQL tables as values
     company_tables: Dict[str, List[str]] = dict()
@@ -245,7 +245,7 @@ def query_stock_database_sql(user_query: str, symbol_list: List[str]) -> Any:
     queries_list = get_sql_queries(selected_schemas, user_query)
 
     # Create a SQL database engine and connect to it using the selected tables
-    engine = create_engine(f'sqlite:///{streamlit.session_state["DB_PATH"]}')
+    engine = create_engine(f'sqlite:///{streamlit.session_state.db_path}')
     db = SQLDatabase(engine=engine, include_tables=selected_tables)
 
     # TODO: With larger context windows
@@ -365,7 +365,7 @@ def query_stock_database_pandasai(user_query: str, symbol_list: List[str]) -> An
             # Insert table name in the prompt
             final_query = user_query.format(table_name=table)
             # Append the response for the given company symbol
-            response[symbol].append(interrogate_table(streamlit.session_state['DB_PATH'], table, final_query))
+            response[symbol].append(interrogate_table(streamlit.session_state.db_path, table, final_query))
 
     return response
 
@@ -386,7 +386,7 @@ def interrogate_table(db_path: str, table: str, user_query: str) -> Any:
     # Instantiate the connector to the SQL database
     connector = SqliteConnector(
         config={
-            'database': streamlit.session_state['DB_PATH'],
+            'database': streamlit.session_state.db_path,
             'table': table,
             'enable_cache': False,
         }
@@ -399,7 +399,7 @@ def interrogate_table(db_path: str, table: str, user_query: str) -> Any:
             'llm': sambanova_llm.llm,
             'open_charts': False,
             'save_charts': True,
-            'save_charts_path': streamlit.session_state['DB_QUERY_FIGURES_DIR'],
+            'save_charts_path': streamlit.session_state.db_query_figures_dir,
             'enable_cache': False,
         },
     )
@@ -408,7 +408,7 @@ def interrogate_table(db_path: str, table: str, user_query: str) -> Any:
     response = 'Table ' + table + ': ' + str(df.chat(user_query))
 
     # Delete the pandasai cache
-    shutil.rmtree(streamlit.session_state['PANDASAI_CACHE'], ignore_errors=True)
+    shutil.rmtree(streamlit.session_state.pandasai_cache, ignore_errors=True)
 
     return response
 
@@ -488,7 +488,7 @@ def get_table_summaries_from_symbols(symbol_list: List[str]) -> str:
         Exception: If there is no SQL table in the database.
     """
     # Instantiate the inspector for the database
-    inspector = Inspector.from_engine(create_engine('sqlite:///' + streamlit.session_state['DB_PATH']))
+    inspector = Inspector.from_engine(create_engine('sqlite:///' + streamlit.session_state.db_path))
 
     # Get the list of SQL tables in the database
     tables_names = inspector.get_table_names()
@@ -531,7 +531,7 @@ def get_table_summaries_from_names(table_names: List[str]) -> str:
     Returns:
         A text summary of SQL tables by their names.
     """
-    inspector = Inspector.from_engine(create_engine('sqlite:///' + streamlit.session_state['DB_PATH']))
+    inspector = Inspector.from_engine(create_engine('sqlite:///' + streamlit.session_state.db_path))
     inspected_tables_names = inspector.get_table_names()
     inspected_tables_names_symbols = [
         inspected_table.split('_')[0].lower() for inspected_table in inspected_tables_names

--- a/financial_assistant/src/tools_filings.py
+++ b/financial_assistant/src/tools_filings.py
@@ -134,7 +134,7 @@ def retrieve_filings(
 
         # Load the dataframe from the text file
         try:
-            df = pandas.read_csv(os.path.join(streamlit.session_state['SOURCE_DIR'], f'{filename}.csv'))
+            df = pandas.read_csv(os.path.join(streamlit.session_state.sources_dir, f'{filename}.csv'))
         except FileNotFoundError:
             logger.error('No scraped data found.')
 
@@ -245,7 +245,7 @@ def parse_filings(
                     f"filing_id_{filing_type.replace('-', '')}_{filing_quarter}_"
                     + f'{ticker_symbol}_{report_date.date().year}'
                 )
-                df.to_csv(os.path.join(streamlit.session_state['SOURCE_DIR'], f'{filename}.csv'), index=False)
+                df.to_csv(os.path.join(streamlit.session_state.sources_dir, f'{filename}.csv'), index=False)
                 break
 
     # If neither the year nor the quarter match, raise an error

--- a/financial_assistant/src/tools_pdf_generation.py
+++ b/financial_assistant/src/tools_pdf_generation.py
@@ -117,10 +117,10 @@ def read_txt_files(directory: str) -> List[str]:
 
     # Target list of text files, used to order the different sources
     target_list = [
-        Path(streamlit.session_state['STOCK_QUERY_PATH']).name,
-        Path(streamlit.session_state['DB_QUERY_PATH']).name,
-        Path(streamlit.session_state['YFINANCE_NEWS_PATH']).name,
-        Path(streamlit.session_state['FILINGS_PATH']).name,
+        Path(streamlit.session_state.stock_query_path).name,
+        Path(streamlit.session_state.db_query_path).name,
+        Path(streamlit.session_state.yfinance_news_path).name,
+        Path(streamlit.session_state.filings_path).name,
     ]
 
     # Sort the files of the list following the order of the target list
@@ -512,7 +512,7 @@ def pdf_rag(user_query: str, pdf_files_names: List[str] | str) -> Any:
     # Load PDF files
     documents = []
     for file in pdf_files_names:
-        pdf_path = os.path.join(streamlit.session_state['PDF_GENERATION_DIRECTORY'], file)
+        pdf_path = os.path.join(streamlit.session_state.pdf_generation_dir, file)
         loader = PyPDFLoader(pdf_path)
         documents.extend(loader.load())
 

--- a/financial_assistant/src/tools_stocks.py
+++ b/financial_assistant/src/tools_stocks.py
@@ -172,7 +172,7 @@ def get_yahoo_connector_answer(user_query: str, symbol: str) -> Any:
     )
 
     # Delete the pandasai cache
-    shutil.rmtree(streamlit.session_state['PANDASAI_CACHE'], ignore_errors=True)
+    shutil.rmtree(streamlit.session_state.pandasai_cache, ignore_errors=True)
 
     # Answer the user query by symbol
     return interrogate_dataframe_pandasai(yahoo_connector, user_query)
@@ -198,13 +198,13 @@ def interrogate_dataframe_pandasai(df_pandas: pandas.DataFrame, user_query: str)
             'llm': sambanova_llm.llm,
             'open_charts': False,
             'save_charts': True,
-            'save_charts_path': streamlit.session_state['STOCK_QUERY_FIGURES_DIR'],
+            'save_charts_path': streamlit.session_state.stock_query_figures_dir,
             'enable_cache': False,
         },
     )
 
     # Delete the pandasai cache
-    shutil.rmtree(streamlit.session_state['PANDASAI_CACHE'], ignore_errors=True)
+    shutil.rmtree(streamlit.session_state.pandasai_cache, ignore_errors=True)
 
     # Add the plot instructions to the user query
     final_query = user_query + '\n' + PLOT_INSTRUCTIONS

--- a/financial_assistant/src/tools_yahoo_news.py
+++ b/financial_assistant/src/tools_yahoo_news.py
@@ -76,7 +76,7 @@ def scrape_yahoo_finance_news(company_list: List[str] | str, user_query: str) ->
     retrieve_text_yahoo_finance_news(link_urls)
     logger.info('News from Yahoo Finance successfully extracted and saved.')
 
-    return get_qa_response_from_news(streamlit.session_state['WEB_SCRAPING_PATH'], user_query)
+    return get_qa_response_from_news(streamlit.session_state.web_scraping_path, user_query)
 
 
 def retrieve_text_yahoo_finance_news(link_urls: List[str]) -> None:
@@ -150,10 +150,10 @@ def retrieve_text_yahoo_finance_news(link_urls: List[str]) -> None:
     df.drop_duplicates().reset_index(drop=True, inplace=True)
 
     # Save the DataFrame to a CSV file
-    df.to_csv(streamlit.session_state['YFINANCE_NEWS_CSV_PATH'], index=False)
+    df.to_csv(streamlit.session_state.yfinance_news_csv_path, index=False)
 
     # Save the data to a text file in the specified order
-    with open(streamlit.session_state['YFINANCE_NEWS_TXT_PATH'], 'w') as file:
+    with open(streamlit.session_state.yfinance_news_txt_path, 'w') as file:
         if RETRIEVE_HEADLINES:
             file.write('=== Headlines ===\n')
             for item in headlines_list:
@@ -175,7 +175,7 @@ def retrieve_text_yahoo_finance_news(link_urls: List[str]) -> None:
     # Convert the list to a DataFrame
     df_text_url = pandas.DataFrame(data)
     # Save the DataFrame to a CSV file
-    df_text_url.to_csv(streamlit.session_state['WEB_SCRAPING_PATH'], index=False)
+    df_text_url.to_csv(streamlit.session_state.web_scraping_path, index=False)
 
 
 def get_url_list(symbol_list: Optional[List[str]] = None) -> List[str]:

--- a/financial_assistant/src/utilities.py
+++ b/financial_assistant/src/utilities.py
@@ -110,9 +110,9 @@ def time_llm(func: F) -> Any:
         # Create a row for the csv file
         row = [func.__name__, duration]
 
-        if os.path.exists(streamlit.session_state['TIME_LLM_PATH']):
+        if os.path.exists(streamlit.session_state.time_llm_path):
             # Read the existing data from the JSON file
-            with open(streamlit.session_state['TIME_LLM_PATH'], 'r') as file:
+            with open(streamlit.session_state.time_llm_path, 'r') as file:
                 data = json.load(file)
         else:
             # If the file does not exist, start with an empty list
@@ -122,7 +122,7 @@ def time_llm(func: F) -> Any:
         data.append(row)
 
         # Save the new list of rows to a JSON file
-        with open(streamlit.session_state['TIME_LLM_PATH'], 'w') as file:
+        with open(streamlit.session_state.time_llm_path, 'w') as file:
             json.dump(data, file, indent=4)
 
         # Return only result

--- a/financial_assistant/streamlit/app.py
+++ b/financial_assistant/streamlit/app.py
@@ -97,27 +97,27 @@ logger = get_logger()
 def main() -> None:
     with streamlit.sidebar:
         # Create the cache and its main subdirectories
-        if are_credentials_set() and not os.path.exists(streamlit.session_state['CACHE_DIR']):
+        if are_credentials_set() and not os.path.exists(streamlit.session_state.cache_dir):
             # List the main cache subdirectories
             subdirectories = [
-                streamlit.session_state['SOURCE_DIR'],
-                streamlit.session_state['PDF_SOURCES_DIR'],
-                streamlit.session_state['PDF_GENERATION_DIRECTORY'],
+                streamlit.session_state.sources_dir,
+                streamlit.session_state.pdf_sources_dir,
+                streamlit.session_state.pdf_generation_dir,
             ]
 
             if prod_mode:
                 # In production mode
-                create_temp_dir_with_subdirs(streamlit.session_state['CACHE_DIR'], subdirectories)
+                create_temp_dir_with_subdirs(streamlit.session_state.cache_dir, subdirectories)
 
                 # In production, schedule deletion after EXIT_TIME_DELTA minutes
                 try:
-                    schedule_temp_dir_deletion(streamlit.session_state['CACHE_DIR'], delay_minutes=EXIT_TIME_DELTA)
+                    schedule_temp_dir_deletion(streamlit.session_state.cache_dir, delay_minutes=EXIT_TIME_DELTA)
                 except:
                     logger.warning('Could not schedule deletion of cache directory.')
 
             else:
                 # In development mode
-                create_temp_dir_with_subdirs(streamlit.session_state['CACHE_DIR'], subdirectories)
+                create_temp_dir_with_subdirs(streamlit.session_state.cache_dir, subdirectories)
 
         # Custom button to exit the app in prod mode
         # This will clear the chat history, delete the cache and clear the SambaNova credentials
@@ -178,39 +178,34 @@ def main() -> None:
                         clear_cache(delete=False)
                         # List the main cache subdirectories
                         subdirectories = [
-                            streamlit.session_state['SOURCE_DIR'],
-                            streamlit.session_state['PDF_SOURCES_DIR'],
-                            streamlit.session_state['PDF_GENERATION_DIRECTORY'],
+                            streamlit.session_state.sources_dir,
+                            streamlit.session_state.pdf_sources_dir,
+                            streamlit.session_state.pdf_generation_dir,
                         ]
-                        delete_all_subdirectories(
-                            directory=streamlit.session_state['CACHE_DIR'], exclude=subdirectories
-                        )
-
+                        delete_all_subdirectories(directory=streamlit.session_state.cache_dir, exclude=subdirectories)
+                        # Clear chat history
+                        streamlit.session_state.chat_history = list()
                         streamlit.sidebar.success('All files have been deleted.')
                     except:
                         pass
 
             # Use Streamlit's session state to persist the current path
             if 'current_path' not in streamlit.session_state:
-                streamlit.session_state.current_path = streamlit.session_state['CACHE_DIR']
+                streamlit.session_state.current_path = streamlit.session_state.cache_dir
 
-            if os.path.exists(streamlit.session_state['CACHE_DIR']):
+            if os.path.exists(streamlit.session_state.cache_dir):
                 # Input to allow user to go back to a parent directory, up to the cache, but not beyond the cache
                 if (
                     streamlit.sidebar.button('⬅️ Back', key=f'back')
-                    and streamlit.session_state['CACHE_DIR'] in streamlit.session_state.current_path
+                    and streamlit.session_state.cache_dir in streamlit.session_state.current_path
                 ):
                     streamlit.session_state.current_path = os.path.dirname(streamlit.session_state.current_path)
 
                     # Display the current directory contents
-                    display_directory_contents(
-                        streamlit.session_state.current_path, streamlit.session_state['CACHE_DIR']
-                    )
+                    display_directory_contents(streamlit.session_state.current_path, streamlit.session_state.cache_dir)
                 else:
                     # Display the current directory contents
-                    display_directory_contents(
-                        streamlit.session_state.current_path, streamlit.session_state['CACHE_DIR']
-                    )
+                    display_directory_contents(streamlit.session_state.current_path, streamlit.session_state.cache_dir)
 
     # Title of the main page
     columns = streamlit.columns([0.15, 0.85], vertical_alignment='top')

--- a/financial_assistant/streamlit/app_financial_filings.py
+++ b/financial_assistant/streamlit/app_financial_filings.py
@@ -70,13 +70,13 @@ def include_financial_filings() -> None:
                 )
 
                 # Save the query and answer to the history text file
-                save_output_callback(answer, streamlit.session_state['HISTORY_PATH'], user_request)
+                save_output_callback(answer, streamlit.session_state.history_path, user_request)
 
                 # Save the query and answer to the filing text file
                 if streamlit.button(
                     'Save Answer',
                     on_click=save_output_callback,
-                    args=(answer, streamlit.session_state['FILINGS_PATH'], user_request),
+                    args=(answer, streamlit.session_state.filings_path, user_request),
                 ):
                     pass
 

--- a/financial_assistant/streamlit/app_pdf_report.py
+++ b/financial_assistant/streamlit/app_pdf_report.py
@@ -90,16 +90,16 @@ def include_pdf_report() -> None:
     data_paths = dict()
     if include_stock:
         # Add data from Stock Data Analysis
-        data_paths['stock_query'] = streamlit.session_state['STOCK_QUERY_PATH']
+        data_paths['stock_query'] = streamlit.session_state.stock_query_path
     if include_database:
         # Add data from Stock Database Analysis
-        data_paths['stock_database'] = streamlit.session_state['DB_QUERY_PATH']
+        data_paths['stock_database'] = streamlit.session_state.db_query_path
     if inlude_yahoo_news:
         # Add data from Yahoo News Analysis
-        data_paths['yfinance_news'] = streamlit.session_state['YFINANCE_NEWS_PATH']
+        data_paths['yfinance_news'] = streamlit.session_state.yfinance_news_path
     if include_filings:
         # Add data from Financial Filings Analysis
-        data_paths['filings'] = streamlit.session_state['FILINGS_PATH']
+        data_paths['filings'] = streamlit.session_state.filings_path
     if generate_from_history:
         # Deselect all other options
         include_stock = False
@@ -108,7 +108,7 @@ def include_pdf_report() -> None:
         include_filings = False
 
         # Add data from chat history
-        data_paths['history'] = streamlit.session_state['HISTORY_PATH']
+        data_paths['history'] = streamlit.session_state.history_path
 
     # Add title name (optional)
     title_name = streamlit.text_input(label='Title Name', value=DEFAULT_PDF_TITLE)
@@ -139,7 +139,7 @@ def include_pdf_report() -> None:
                     stream_time_llm()
 
                     # Delete LLM time json file
-                    os.remove(streamlit.session_state['TIME_LLM_PATH'])
+                    os.remove(streamlit.session_state.time_llm_path)
 
                     base64_pdf = b64encode(pdf_handler).decode('utf-8')
                     pdf_display = (
@@ -186,9 +186,8 @@ def include_pdf_report() -> None:
             # Get list of files in the directory
             files = [
                 f
-                for f in os.listdir(streamlit.session_state['PDF_GENERATION_DIRECTORY'])
-                if os.path.isfile(os.path.join(streamlit.session_state['PDF_GENERATION_DIRECTORY'], f))
-                and f.endswith('.pdf')
+                for f in os.listdir(streamlit.session_state.pdf_generation_dir)
+                if os.path.isfile(os.path.join(streamlit.session_state.pdf_generation_dir, f)) and f.endswith('.pdf')
             ]
 
             if len(files) > 0:
@@ -234,9 +233,7 @@ def include_pdf_report() -> None:
                 # Store uploaded files
                 streamlit.session_state.uploaded_files = [file.name for file in uploaded_files]
                 for file_item in uploaded_files:
-                    with open(
-                        os.path.join(streamlit.session_state['PDF_GENERATION_DIRECTORY'], file_item.name), 'wb'
-                    ) as f:
+                    with open(os.path.join(streamlit.session_state.pdf_generation_dir, file_item.name), 'wb') as f:
                         f.write(file_item.getbuffer())
 
         # The user request
@@ -276,7 +273,7 @@ def include_pdf_report() -> None:
                         if streamlit.button(
                             'Save Answer',
                             on_click=save_output_callback,
-                            args=(content, streamlit.session_state['PDF_RAG_PATH']),
+                            args=(content, streamlit.session_state.pdf_rag_path),
                         ):
                             pass
 
@@ -308,7 +305,7 @@ def include_pdf_report() -> None:
                         if streamlit.button(
                             'Save Answer',
                             on_click=save_output_callback,
-                            args=(content, streamlit.session_state['PDF_RAG_PATH']),
+                            args=(content, streamlit.session_state.pdf_rag_path),
                         ):
                             pass
 
@@ -338,11 +335,11 @@ def handle_pdf_generation(
     """
 
     # Clean the sources directory if it exists
-    if os.path.exists(streamlit.session_state['PDF_SOURCES_DIR']):
-        clear_directory(streamlit.session_state['PDF_SOURCES_DIR'])
+    if os.path.exists(streamlit.session_state.pdf_sources_dir):
+        clear_directory(streamlit.session_state.pdf_sources_dir)
 
     # Derive the output file name
-    output_file = os.path.join(streamlit.session_state['PDF_GENERATION_DIRECTORY'], report_name)
+    output_file = os.path.join(streamlit.session_state.pdf_generation_dir, report_name)
 
     # Check that at least one data source is available
     if not any([data_paths[key] for key in data_paths]):
@@ -358,7 +355,7 @@ def handle_pdf_generation(
 
     for source_file in data_paths.values():
         # Create the full path for the destination file
-        destination_file = os.path.join(streamlit.session_state['PDF_SOURCES_DIR'], os.path.basename(source_file))
+        destination_file = os.path.join(streamlit.session_state.pdf_sources_dir, os.path.basename(source_file))
 
         try:
             # Copy selected document to the pdf generation directory
@@ -369,7 +366,7 @@ def handle_pdf_generation(
             logger.error('Error while copying file', exc_info=True)
 
     # Extract the documents from the selected files
-    documents = read_txt_files(streamlit.session_state['PDF_SOURCES_DIR'])
+    documents = read_txt_files(streamlit.session_state.pdf_sources_dir)
 
     # Parse the documents into a list of tuples of text and figure paths
     report_content = parse_documents(documents)

--- a/financial_assistant/streamlit/app_stock_data.py
+++ b/financial_assistant/streamlit/app_stock_data.py
@@ -97,13 +97,13 @@ def get_stock_data_analysis() -> None:
                 response_dict = handle_stock_query(user_request, dataframe_name)
 
                 # Save the output to the history file
-                save_output_callback(response_dict, streamlit.session_state['HISTORY_PATH'], user_request)
+                save_output_callback(response_dict, streamlit.session_state.history_path, user_request)
 
                 # Save the output to the stock query file
                 if streamlit.button(
                     'Save Answer',
                     on_click=save_output_callback,
-                    args=(response_dict, streamlit.session_state['STOCK_QUERY_PATH'], user_request),
+                    args=(response_dict, streamlit.session_state.stock_query_path, user_request),
                 ):
                     pass
 
@@ -131,7 +131,7 @@ def get_stock_data_analysis() -> None:
 
             # Save the output to the history file
             save_historical_price_callback(
-                user_request, symbol_list, data, fig, start_date, end_date, streamlit.session_state['HISTORY_PATH']
+                user_request, symbol_list, data, fig, start_date, end_date, streamlit.session_state.history_path
             )
 
             # Save the output to the stock query file
@@ -145,7 +145,7 @@ def get_stock_data_analysis() -> None:
                     fig,
                     start_date,
                     end_date,
-                    streamlit.session_state['STOCK_QUERY_PATH'],
+                    streamlit.session_state.stock_query_path,
                 ),
             ):
                 pass

--- a/financial_assistant/streamlit/app_stock_database.py
+++ b/financial_assistant/streamlit/app_stock_database.py
@@ -66,13 +66,13 @@ def get_stock_database() -> None:
                 response_dict = handle_database_query(user_request, query_method)
 
                 # Save the query and answer to the history text file
-                save_output_callback(response_dict, streamlit.session_state['HISTORY_PATH'], user_request)
+                save_output_callback(response_dict, streamlit.session_state.history_path, user_request)
 
                 # Save the query and answer to the database query text file
                 if streamlit.button(
                     'Save Query',
                     on_click=save_output_callback,
-                    args=(response_dict, streamlit.session_state['DB_QUERY_PATH'], user_request),
+                    args=(response_dict, streamlit.session_state.db_query_path, user_request),
                 ):
                     pass
 

--- a/financial_assistant/streamlit/app_yfinance_news.py
+++ b/financial_assistant/streamlit/app_yfinance_news.py
@@ -43,13 +43,13 @@ def get_yfinance_news() -> None:
                 content = answer + '\n\n'.join(url_list)
 
                 # Save the query and answer to the history text file
-                save_output_callback(content, streamlit.session_state['HISTORY_PATH'], user_request)
+                save_output_callback(content, streamlit.session_state.history_path, user_request)
 
                 # Save the query and answer to the Yahoo Finance News text file
                 if streamlit.button(
                     'Save Answer',
                     on_click=save_output_callback,
-                    args=(content, streamlit.session_state['YFINANCE_NEWS_PATH'], user_request),
+                    args=(content, streamlit.session_state.yfinance_news_path, user_request),
                 ):
                     pass
 

--- a/financial_assistant/streamlit/utilities_methods.py
+++ b/financial_assistant/streamlit/utilities_methods.py
@@ -86,7 +86,7 @@ def handle_userinput(user_question: str, user_query: str) -> Optional[Any]:
                 stream_time_llm()
 
                 # Delete LLM time json file
-                os.remove(streamlit.session_state['TIME_LLM_PATH'])
+                os.remove(streamlit.session_state.time_llm_path)
 
             except LLMException:
                 streamlit.error(LLM_EXCEPTION_MESSAGE)
@@ -112,8 +112,8 @@ def handle_userinput(user_question: str, user_query: str) -> Optional[Any]:
 def stream_time_llm() -> None:
     """Stream LLM call duration."""
 
-    if os.path.exists(streamlit.session_state['TIME_LLM_PATH']):
-        with open(streamlit.session_state['TIME_LLM_PATH'], 'r') as file:
+    if os.path.exists(streamlit.session_state.time_llm_path):
+        with open(streamlit.session_state.time_llm_path, 'r') as file:
             data = json.load(file)
             while data:
                 streamlit.markdown(

--- a/financial_assistant/tests/financial_assistant_test.py
+++ b/financial_assistant/tests/financial_assistant_test.py
@@ -83,11 +83,11 @@ class FinancialAssistantTest(unittest.TestCase):
 
         # Create the cache and its main subdirectories
         subdirectories = [
-            streamlit.session_state['SOURCE_DIR'],
-            streamlit.session_state['PDF_SOURCES_DIR'],
-            streamlit.session_state['PDF_GENERATION_DIRECTORY'],
+            streamlit.session_state.sources_dir,
+            streamlit.session_state.pdf_sources_dir,
+            streamlit.session_state.pdf_generation_dir,
         ]
-        create_temp_dir_with_subdirs(streamlit.session_state['CACHE_DIR'], subdirectories)
+        create_temp_dir_with_subdirs(streamlit.session_state.cache_dir, subdirectories)
 
         # List of available methods for database query
         self.method_list = ['text-to-SQL', 'PandasAI-SqliteConnector']
@@ -134,7 +134,7 @@ class FinancialAssistantTest(unittest.TestCase):
         self.check_get_stock_info(response)
 
         # Save response to cache
-        save_output_callback(response, streamlit.session_state['STOCK_QUERY_PATH'], query)
+        save_output_callback(response, streamlit.session_state.stock_query_path, query)
 
     def test_get_historical_price(self) -> None:
         """Test for the tool `get_historical_price`."""
@@ -175,7 +175,7 @@ class FinancialAssistantTest(unittest.TestCase):
             response[0],
             DEFAULT_START_DATE,
             DEFAULT_END_DATE,
-            streamlit.session_state['STOCK_QUERY_PATH'],
+            streamlit.session_state.stock_query_path,
         )
 
     def test_create_stock_database(self) -> None:
@@ -257,7 +257,7 @@ class FinancialAssistantTest(unittest.TestCase):
             self.check_query_stock_database(response, method)
 
             # Save response to cache
-            save_output_callback(response, streamlit.session_state['DB_QUERY_PATH'], query)
+            save_output_callback(response, streamlit.session_state.db_query_path, query)
 
     def test_scrape_yahoo_finance_news(self) -> None:
         """Test for the tool `scrape_yahoo_finance_news`."""
@@ -289,7 +289,7 @@ class FinancialAssistantTest(unittest.TestCase):
 
         # Save response to cache
         content = response + '\n\n'.join(url_list)
-        save_output_callback(content, streamlit.session_state['YFINANCE_NEWS_PATH'], query)
+        save_output_callback(content, streamlit.session_state.yfinance_news_path, query)
 
     def test_retrieve_filings(self) -> None:
         """Test for the tool `retrieve_filings`."""
@@ -327,7 +327,7 @@ class FinancialAssistantTest(unittest.TestCase):
         self.check_retrieve_filings(response)
 
         # Save response to cache
-        save_output_callback(response, streamlit.session_state['FILINGS_PATH'], query)
+        save_output_callback(response, streamlit.session_state.filings_path, query)
 
     def test_handle_pdf_generation(self) -> None:
         """Test the tool `handle_pdf_generation`."""
@@ -336,10 +336,10 @@ class FinancialAssistantTest(unittest.TestCase):
         report_name = report_title.lower().replace(' ', '_') + '.pdf'
 
         data_paths = dict()
-        data_paths['stock_query'] = streamlit.session_state['STOCK_QUERY_PATH']
-        data_paths['stock_database'] = streamlit.session_state['DB_QUERY_PATH']
-        data_paths['yfinance_news'] = streamlit.session_state['YFINANCE_NEWS_PATH']
-        data_paths['filings'] = streamlit.session_state['FILINGS_PATH']
+        data_paths['stock_query'] = streamlit.session_state.stock_query_path
+        data_paths['stock_database'] = streamlit.session_state.db_query_path
+        data_paths['yfinance_news'] = streamlit.session_state.yfinance_news_path
+        data_paths['filings'] = streamlit.session_state.filings_path
 
         # Generate the PDF report
         pdf_handler = handle_pdf_generation(report_title, report_name, data_paths, True)
@@ -357,7 +357,7 @@ class FinancialAssistantTest(unittest.TestCase):
         query = DEFAULT_PDF_RAG_QUERY
 
         # The pdf files names
-        pdf_files_names = [os.path.join(streamlit.session_state['PDF_GENERATION_DIRECTORY'], report_name)]
+        pdf_files_names = [os.path.join(streamlit.session_state.pdf_generation_dir, report_name)]
 
         # Invoke the tool to answer the user query
         response = pdf_rag.invoke(
@@ -380,7 +380,7 @@ class FinancialAssistantTest(unittest.TestCase):
         query = DEFAULT_PDF_RAG_QUERY
 
         # The pdf files names
-        pdf_files_names = [os.path.join(streamlit.session_state['PDF_GENERATION_DIRECTORY'], report_name)]
+        pdf_files_names = [os.path.join(streamlit.session_state.pdf_generation_dir, report_name)]
 
         # Invoke the LLM to answer the user query
         response = handle_pdf_rag(query, pdf_files_names)


### PR DESCRIPTION
1. Rename `session_state` paths to be consistent with the remainder and the previous usage and be more readable.
2. Add if clauses before `session_state` initializations of the path names.
3. Delete unused functions to reload packages.
4. Clear history in "Clear all files" for consistency and to avoid errors in finding the figures that have been deleted from the cache.