### PR TITLE
[CLOUD-4610] Add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,36 @@
+name: gitleaks
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0            # full history so the scan is complete
+      - name: Install and run gitleaks (non-blocking)
+        continue-on-error: true     # reports findings, does not fail the PR yet
+        run: |
+          VERSION=8.28.0
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          code=0
+          ./gitleaks detect --source . --redact -v \
+            --config .gitleaks.toml \
+            --report-format json --report-path gitleaks-report.json || code=$?
+          count=$(jq 'length' gitleaks-report.json 2>/dev/null || echo 0)
+          {
+            echo "## gitleaks: ${count} finding(s)"
+            if [ "$count" -gt 0 ]; then
+              echo ""
+              echo "| Rule | File | Line | Commit |"
+              echo "| --- | --- | --- | --- |"
+              jq -r '.[] | "| \(.RuleID) | \(.File) | \(.StartLine) | \(.Commit[0:8]) |"' gitleaks-report.json
+              echo ""
+              echo "_Secrets redacted. Findings are historical — clean up rather than just delete. Non-blocking during rollout._"
+            else
+              echo "No findings."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $code

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+# Gitleaks config for ai-starter-kit.
+# Extends the built-in default ruleset. Allowlists cover documentation and
+# tutorial example keys — this is a demo/starter repo, so sample keys in prose
+# and notebooks are expected, not real credentials.
+title = "ai-starter-kit gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Docs, tutorial notebooks, and placeholder sample keys"
+paths = [
+  '''.*\.md$''',                     # README/docs — example keys in prose
+  '''.*\.ipynb$''',                  # tutorial notebooks — example keys in cells
+  '''utils/parsing/config\.yaml''',  # placeholder key value
+]
+regexes = [
+  '''123456789abcde''',              # obvious placeholder used in sample configs
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,9 @@ repos:
       args: [--config=ruff.toml, --fix]
     # Formatting
     - id: ruff-format
+
+  # Secret scanning
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.28.0
+  hooks:
+    - id: gitleaks


### PR DESCRIPTION
Adds gitleaks secret scanning to this repo.

- `.gitleaks.toml` — extends gitleaks' default rules; allowlists docs, tutorial notebooks, and placeholder sample keys, since this is a starter/demo repo.
- `.pre-commit-config.yaml` — adds the gitleaks hook next to the existing ruff hooks, so secrets are caught before they're committed.
- `.github/workflows/gitleaks.yml` — scans on pull requests and pushes to `main`. Non-blocking for now: it reports findings but won't fail the build, so we can clear false positives before turning on enforcement.

Part of the org-wide secret-scanning rollout (CLOUD-4610).
