### PR TITLE
Improvement: Bug fix for real workload test in bundles module

### DIFF
--- a/benchmarking/benchmarking_bundles/synthetic_performance_eval_script.py
+++ b/benchmarking/benchmarking_bundles/synthetic_performance_eval_script.py
@@ -516,11 +516,14 @@ class BenchmarkRunner:
 
         model_name = row['model_name']
         num_requests = int(row['num_requests'])
-        num_warmup_requests = int(row.get('num_warmup_requests', 0) or 0)
+        num_warmup_requests_val = row.get('num_warmup_requests', 0)
+        num_warmup_requests = int(num_warmup_requests_val) if pd.notna(num_warmup_requests_val) else 0
         input_tokens = int(row['input_tokens'])
         output_tokens = int(row['output_tokens'])
-        concurrent_requests = int(row.get('concurrent_requests', 0) or 0)
-        qps = float(row.get('qps', 0.0) or 0.0)
+        concurrent_requests_val = row.get('concurrent_requests', 0)
+        concurrent_requests = int(concurrent_requests_val) if pd.notna(concurrent_requests_val) else 0
+        qps_val = row.get('qps', 0.0)
+        qps = float(qps_val) if pd.notna(qps_val) else 0.0
         multimodal_img_size = row.get('multimodal_img_size') if pd.notna(row.get('multimodal_img_size')) else 'na'
 
         evaluator = None


### PR DESCRIPTION
## Summary
- Fixes a `ValueError: cannot convert float NaN to integer` crash in `synthetic_performance_eval_script.py::_run_single_row` when running QPS-mode bundle configs (e.g. `./run_synthetic_perfomance_bundle_eval.sh`) whose CSV intentionally leaves `concurrent_requests` blank for QPS-mode rows.
- Root cause: `row.get('concurrent_requests', 0) or 0` does not catch `NaN` because `bool(float('nan'))` is `True` in Python, so `NaN or 0` evaluates to `NaN`, and `int(NaN)` raises.
- Applies the same `pd.notna(...)` guard already used for `multimodal_img_size` to `num_warmup_requests`, `concurrent_requests`, and `qps`, so blank/missing values in any of these columns now correctly default to `0`/`0.0` instead of crashing.

## Test plan
- [x] Verified `pandas` is already imported in the module (no new import needed)
- [x] `python3 -m py_compile` passes on the edited file
- [x] Simulated both row shapes (concurrent-mode row with `concurrent_requests` set/`qps` blank, and QPS-mode row with `concurrent_requests`/`num_warmup_requests` blank/`qps` set) through the new parsing logic — both resolve without error and route to the correct evaluator (`SyntheticPerformanceEvaluator` vs `RealWorkLoadPerformanceEvaluator`)
- [x] Confirmed non-NaN values still cast identically to the previous behavior (no change for fully-populated rows)